### PR TITLE
Fixed wrong exitcode for cURL and docker-compose fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,4 +41,4 @@ jobs:
 
       - name: Run PING command
         run: |
-          docker exec -it master bash -c "/opt/redislabs/bin/redis-cli -p ${{ env.RE_DB_PORT }} ping"
+          docker exec -it -t master bash -c "/opt/redislabs/bin/redis-cli -p ${{ env.RE_DB_PORT }} ping"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,4 +41,4 @@ jobs:
 
       - name: Run PING command
         run: |
-          docker exec -it -t master bash -c "/opt/redislabs/bin/redis-cli -p ${{ env.RE_DB_PORT }} ping"
+          docker exec master bash -c "/opt/redislabs/bin/redis-cli -p ${{ env.RE_DB_PORT }} ping"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,4 +41,4 @@ jobs:
 
       - name: Run PING command
         run: |
-          docker-compose exec -T master-node bash -c "/opt/redislabs/bin/redis-cli -p ${{ env.RE_DB_PORT }} ping"
+          docker exec -it master bash -c "/opt/redislabs/bin/redis-cli -p ${{ env.RE_DB_PORT }} ping"

--- a/create_db.sh
+++ b/create_db.sh
@@ -2,4 +2,4 @@
 
 curl -u $RE_USERNAME:$RE_PASS -H "Content-type: application/json" \
              -d '{"name": "db", "port": '$RE_DB_PORT', "memory_size": 1273741824, "replication": false, "eviction_policy": "volatile-lru", "sharding": true, "shards_count": 3, "module_list": [{"module_args": "", "module_name": "ReJSON"},{"module_args": "", "module_name": "search"},{"module_args": "", "module_name": "timeseries"},{"module_args": "", "module_name": "bf"}], "oss_cluster": '$RE_USE_OSS_CLUSTER', "proxy_policy": "all-nodes", "shards_placement": "sparse", "shard_key_regex": [{"regex": ".*\\{(?<tag>.*)\\}.*"},{"regex": "(?<tag>.*)"}]}' \
-             -k -X POST https://localhost:9443/v1/bdbs
+             -k -X POST -f https://localhost:9443/v1/bdbs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.9"
 services:
   master-node:
     image: "${IMAGE}"
+    container_name: "master"
     cap_add:
       - SYS_RESOURCE
     ports:
@@ -25,6 +26,7 @@ services:
 
   node-1:
     image: "${IMAGE}"
+    container_name: "slave-1"
     cap_add:
       - SYS_RESOURCE
     depends_on:
@@ -48,6 +50,7 @@ services:
 
   node-2:
     image: "${IMAGE}"
+    container_name: "slave-2"
     cap_add:
       - SYS_RESOURCE
     depends_on:


### PR DESCRIPTION
In CI if cURL or PING command fails it didn't fail pipeline because of wrong exitcode on failure. This PR aims to fix both of this issues.