### PR TITLE
Increased timeout to avoid service unavailable error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ fi
 
 ## Build infrastructure ##
 docker-compose up -d
-sleep 10
+sleep 15
 
 ## Create cluster ##
 docker-compose exec -T master-node "/opt/setup_cluster.sh"


### PR DESCRIPTION
Timeout should be increased cause 10 seconds is not enough for GitHub actions CI to properly run infrastructure after `docker-compose up -d`. It leads to this kind of error when it's tries to create cluster, but service still unavailable

https://github.com/vladvildanov/predis/actions/runs/7709095086/job/21009537690