### PR TITLE
Make sure the container is run in a supported architecture for unsupported architectures

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
 
 if [[ -n "${DOCKER_ACCESS_TOKEN}" ]]; then
   echo $DOCKER_ACCESS_TOKEN | docker login --username=$DOCKER_USERNAME --password-stdin

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-export DOCKER_DEFAULT_PLATFORM=linux/amd64
 
 if [[ -n "${DOCKER_ACCESS_TOKEN}" ]]; then
   echo $DOCKER_ACCESS_TOKEN | docker login --username=$DOCKER_USERNAME --password-stdin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   master-node:
     image: "${IMAGE}"
     container_name: "master"
+    platform: linux/amd64
     cap_add:
       - SYS_RESOURCE
     healthcheck:
@@ -32,6 +33,7 @@ services:
   node-1:
     image: "${IMAGE}"
     container_name: "slave-1"
+    platform: linux/amd64
     cap_add:
       - SYS_RESOURCE
     depends_on:
@@ -62,6 +64,7 @@ services:
   node-2:
     image: "${IMAGE}"
     container_name: "slave-2"
+    platform: linux/amd64
     cap_add:
       - SYS_RESOURCE
     depends_on:


### PR DESCRIPTION
Fixes issues with MacOS

see [discussion](https://stackoverflow.com/questions/65612411/forcing-docker-to-use-linux-amd64-platform-by-default-on-macos) on the topic